### PR TITLE
Disable *Silent* SSO.

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -13,7 +13,6 @@ config.auth0 = {
   domain: process.env.AUTH0_DOMAIN,
   scope: 'profile',
   sso_logout_url: '/v2/logout',
-  prompt: 'none',
 };
 
 config.express = {

--- a/app/routes.js
+++ b/app/routes.js
@@ -36,10 +36,7 @@ router.get('/login', (req, res, next) => {
       res.redirect(req.session.returnTo);
     }
   } else {
-    passport.authenticate(
-      'auth0-oidc',
-      { prompt: req.query.prompt || config.auth0.prompt },
-    )(req, res, next);
+    passport.authenticate('auth0-oidc')(req, res, next);
   }
 });
 
@@ -54,7 +51,7 @@ router.get('/logout', (req, res) => {
 
 /* Handle auth callback */
 router.get('/callback', [
-  passport.authenticate('auth0-oidc', { failureRedirect: '/login?prompt=true' }),
+  passport.authenticate('auth0-oidc', { failureRedirect: '/login' }),
   (req, res) => {
     res.redirect(req.session.returnTo || '/');
   },


### PR DESCRIPTION
For two reasons:
1) In the case of kibana we don't want to be automatically logged in with
Github as we may want to login in with Google (as admin)
2) Google authentication when passing `prompt` breaks for some reason

Part of ticket: https://trello.com/c/robNgbzG/651-3-update-kibana-auth-proxy-to-use-hosted-auth0-login